### PR TITLE
Modernize the README (trove-style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,110 @@
+<div align="center">
 
-# [Sepomex](https://github.com/IcaliaLabs/sepomex)
+# 📮 Sepomex
 
-Sepomex is a REST API that maps all the data from the current zip codes in Mexico. You can get the CSV or Excel files from the [official site](https://www.correosdemexico.gob.mx/SSLServicios/ConsultaCP/CodigoPostal_Exportar.aspx)
+### The open REST **and** MCP API for Mexico's postal codes
 
-We build this API in order to provide a way to developers query the zip codes, states and municipalities across the country.
+**Every Mexican zip code, state, municipality, city and settlement — one bundled SQLite database, no API key, no rate limit.**
 
-It also ships a **[Model Context Protocol](#mcp-model-context-protocol) server**, so AI agents can query the same data as tools.
+[![Release](https://img.shields.io/github/v/release/IcaliaLabs/sepomex?color=c2693d&label=release)](https://github.com/IcaliaLabs/sepomex/releases)
+[![Build](https://img.shields.io/github/actions/workflow/status/IcaliaLabs/sepomex/ci-and-cd.yml?branch=main&color=c2693d&label=build)](https://github.com/IcaliaLabs/sepomex/actions)
+[![Ruby](https://img.shields.io/badge/Ruby-3.4.7-c2693d)](.ruby-version)
+[![Rails](https://img.shields.io/badge/Rails-8.1-c2693d)](Gemfile)
+[![MCP](https://img.shields.io/badge/MCP-ready-c2693d)](#-mcp-server)
+[![License](https://img.shields.io/badge/License-MIT-c2693d)](LICENSE)
 
-**Stack:** Ruby 3.4 · Rails 8.1 (API-only) · SQLite (bundled data) · Puma.
+[Quick start](#-quick-start) · [Querying the API](#-querying-the-api) · [MCP server](#-mcp-server) · [Development](#️-development) · [Architecture](#-architecture)
 
-## Table of contents
+</div>
 
-- [Quick start](#quick-start)
-- [Querying the API](#querying-the-api)
-- [About pagination](#about-pagination)
-- [MCP (Model Context Protocol)](#mcp-model-context-protocol)
-- [Development](#development)
-  - [Setup the project](#setup-the-project)
-  - [Running the project](#running-the-project)
-  - [Stop the project](#stop-the-project)
-  - [Running specs](#running-specs)
-- [Changelog](#changelog)
-- [Contributing](#contributing)
-- [License](#license)
+---
 
-## Quick start
+## Why Sepomex?
 
-The base URI to start consuming the JSON response is under:
+Looking up a Mexican postal code usually means scraping the official Correos de México site or wrangling a clunky Excel export. Sepomex turns that same official dataset into a clean, paginated JSON API you can query by zip code, state, city, municipality or colony — and, as of v1.0.0, exposes it to AI agents through the **Model Context Protocol** as well.
+
+The whole catalog (~154k settlements) ships **inside the app as a SQLite database**, so there's nothing external to provision: clone, load, run.
+
+## ✨ Features
+
+- 🔎 **Search that fits the question** — query zip codes by `zip_code`, `state`, `city`, `colony`, or any combination, accent- and case-insensitive.
+- 🧭 **Four resources** — zip codes (settlements), states, municipalities and cities, each with `show` and paginated `index` endpoints.
+- 📄 **Predictable pagination** — every list response carries a `meta.pagination` block plus `Link` / `X-Total-*` headers.
+- 🤖 **MCP server built in** — the same data as agentic tools over Streamable HTTP (`/mcp`) and stdio (`bin/mcp`).
+- 🗃️ **Zero external dependencies** — bundled SQLite dataset; no Postgres, no Redis, no API keys.
+- 🌐 **CORS-friendly & read-only** — safe to call straight from the browser.
+- 🐳 **Dockerized** — multi-stage build, one-command dev environment, CI that ships images to Docker Hub.
+
+> **No key, no quota, no tracking.** Sepomex is a read-only public API over public data. Run the hosted instance or host your own in minutes — the dataset travels with the code.
+
+## 🚀 Quick start
+
+The base URI for the hosted JSON API:
 
 ```bash
-http://sepomex.icalialabs.com/api/v1/zip_codes
+https://sepomex.icalialabs.com/api/v1
 ```
 
-There are currently `154,650` settlement records on the database which were extracted from the [CSV file](https://github.com/IcaliaLabs/sepomex/blob/master/lib/sepomex_db.csv) included in the project.
-
-Records are paginated with **15** records per page.
-
-See [Development](#development) to run the project locally or with Docker. A
-liveness/readiness probe is available at `GET /up` (returns `200` when the app
-boots healthy). For AI agents, the same data is available through the
-[MCP server](#mcp-model-context-protocol).
-
-## Querying the API
-
-We currently provide 4 kind of resources:
-
-- **Zip Codes**: [http://sepomex.icalialabs.com/zip_codes](https://sepomex.icalialabs.com/api/v1/zip_codes)
-- **States**: [http://sepomex.icalialabs.com/states](https://sepomex.icalialabs.com/api/v1/states)
-- **Municipalities**: [http://sepomex.icalialabs.com/municipalities](https://sepomex.icalialabs.com/api/v1/municipalities)
-- **Cities**: [http://sepomex.icalialabs.com/cities](https://sepomex.icalialabs.com/api/v1/cities)
-
-### Items per page
-The 4 resources you can query are paginated with 15 items per page by default. You can change the number of items per page by adding the `per_page` parameter to the query string.
+Grab every settlement for a postal code:
 
 ```bash
-### ZipCodes
-
-In order to provide more flexibility to search a zip code, whether is by city, colony, state or zip code you can now send multiple parameters to make the appropiate search. You can fetch the:
-### ZipCodes
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/zip_codes?per_page=200
-```
-You can't request more than 200 items per page, if you do so, the API will return 15 items per page.
-
-Also, you can mix the `per_page` parameter with the `page` parameter to get the desired page, even with the search parameters.
-
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/zip_codes?per_page=200&page=2
+curl "https://sepomex.icalialabs.com/api/v1/zip_codes?zip_code=64000"
 ```
 
-##### Response
+```json
+{
+  "zip_codes": [
+    {
+      "id": 1,
+      "d_codigo": "64000",
+      "d_asenta": "Centro",
+      "d_tipo_asenta": "Colonia",
+      "d_mnpio": "Monterrey",
+      "d_estado": "Nuevo León",
+      "d_cp": "64000",
+      "...": "..."
+    }
+  ],
+  "meta": { "pagination": { "per_page": 15, "total_pages": 1, "total_objects": 1, "links": { "first": "…", "last": "…" } } }
+}
+```
+
+Prefer to run it yourself? Jump to [Development](#️-development). A health probe lives at `GET /up`.
+
+## 🧭 Querying the API
+
+Four resources, all under `/api/v1`:
+
+| Resource | Endpoint | Notes |
+| --- | --- | --- |
+| **Zip codes** | `GET /zip_codes` | Searchable by `zip_code`, `state`, `city`, `colony` |
+| **States** | `GET /states` · `GET /states/:id` | `GET /states/:id/municipalities` for its municipalities |
+| **Municipalities** | `GET /municipalities` · `GET /municipalities/:id` | |
+| **Cities** | `GET /cities` · `GET /cities/:id` | |
+
+### Searching zip codes
+
+Mix and match any of the search parameters — matching is partial and accent-insensitive:
+
+```bash
+# by postal code
+curl "https://sepomex.icalialabs.com/api/v1/zip_codes?zip_code=67173"
+
+# by city / municipality
+curl "https://sepomex.icalialabs.com/api/v1/zip_codes?city=monterrey"
+
+# by state
+curl "https://sepomex.icalialabs.com/api/v1/zip_codes?state=nuevo%20leon"
+
+# by colony (settlement)
+curl "https://sepomex.icalialabs.com/api/v1/zip_codes?colony=del%20valle"
+
+# all together
+curl "https://sepomex.icalialabs.com/api/v1/zip_codes?state=nuevo%20leon&city=guadalupe&colony=del%20valle"
+```
+
+<details>
+<summary>Example zip code response</summary>
 
 ```json
 {
@@ -91,8 +126,7 @@ curl -X GET https://sepomex.icalialabs.com/api/v1/zip_codes?per_page=200&page=2
       "id_asenta_cpcons": "0001",
       "d_zona": "Urbano",
       "c_cve_ciudad": "01"
-    },
-    ...
+    }
   ],
   "meta": {
     "pagination": {
@@ -100,296 +134,88 @@ curl -X GET https://sepomex.icalialabs.com/api/v1/zip_codes?per_page=200&page=2
       "total_pages": 9728,
       "total_objects": 145906,
       "links": {
-        "first": "/zip_code?page=1",
-        "last": "/zip_code?page=9728",
-        "next": "/zip_code?page=2"
+        "first": "/api/v1/zip_codes?page=1",
+        "last": "/api/v1/zip_codes?page=9728",
+        "next": "/api/v1/zip_codes?page=2"
       }
     }
   }
 }
 ```
 
-#### by city
+</details>
+
+### States, municipalities & cities
 
 ```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/zip_codes?city=monterrey
+curl "https://sepomex.icalialabs.com/api/v1/states"
+curl "https://sepomex.icalialabs.com/api/v1/states/1"
+curl "https://sepomex.icalialabs.com/api/v1/states/1/municipalities"
+curl "https://sepomex.icalialabs.com/api/v1/municipalities/1"
+curl "https://sepomex.icalialabs.com/api/v1/cities/1"
 ```
 
-#### by state
-
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/zip_codes?state=nuevo%20leon
-```
-
-#### by colony
-
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/zip_codes?colony=punta%20contry
-```
-
-#### by cp
-
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/zip_codes?zip_code=67173
-```
-
-#### all together
-
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/zip_codes?colony=punta%20contry&state=nuevo%20leon&city=guadalupe
-```
-
-### States
-
-The `states` resources can be fetch through several means:
-
-#### all
-
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/states
-```
-
-##### Response
+<details>
+<summary>Example state & municipality responses</summary>
 
 ```json
-{
+// GET /api/v1/states/1
+{ "state": { "id": 1, "name": "Ciudad de México", "cities_count": 16 } }
 
-  "states": [
-    {
-      "id": 1,
-      "name": "Ciudad de México",
-      "cities_count": 16
-    },
-    ...
-  ],
-  "meta": {
-    "pagination": {
-      "per_page": 15,
-      "total_pages": 3,
-      "total_objects": 32,
-      "links": {
-        "first": "/state?page=1",
-        "last": "/state?page=3",
-        "next": "/state?page=2"
-      }
-    }
-  }
-}
-```
-
-#### by id
-
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/states/1
-```
-
-##### Response
-
-```json
-{
-  "state": {
-    "id": 1,
-    "name": "Ciudad de México",
-    "cities_count": 16
-  }
-}
-```
-
-#### states municipalities
-
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/states/1/municipalities
-```
-
-##### Response
-
-```json
+// GET /api/v1/states/1/municipalities
 {
   "municipalities": [
-    {
-      "id": 1,
-      "name": "Álvaro Obregón",
-      "municipality_key": "010",
-      "zip_code": "01001",
-      "state_id": 1
-    },
-    ...
-    {
-      "id": 16,
-      "name": "Xochimilco",
-      "municipality_key": "013",
-      "zip_code": "16001",
-      "state_id": 1
-    }
+    { "id": 1, "name": "Álvaro Obregón", "municipality_key": "010", "zip_code": "01001", "state_id": 1 },
+    { "id": 16, "name": "Xochimilco", "municipality_key": "013", "zip_code": "16001", "state_id": 1 }
   ]
 }
 ```
 
-### Municipalities
+</details>
 
-#### all
+### Pagination
 
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/municipalities
-```
-
-##### Response
-
-```json
-{
-  "municipalities": [
-    {
-      "id": 1,
-      "name": "Álvaro Obregón",
-      "municipality_key": "010",
-      "zip_code": "01001",
-      "state_id": 1
-    },
-    ...
-  ],
-  "meta": {
-    "pagination": {
-      "per_page": 15,
-      "total_pages": 155,
-      "total_objects": 2318,
-      "links": {
-        "first": "/municipality?page=1",
-        "last": "/municipality?page=155",
-        "next": "/municipality?page=2"
-      }
-    }
-  }
-}
-```
-
-#### by id
+Every `index` response is paginated — **15 per page** by default, up to **200** via `per_page` (larger values fall back to 15). Combine `per_page` with `page`:
 
 ```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/municipalities/1
+curl "https://sepomex.icalialabs.com/api/v1/zip_codes?per_page=200&page=2"
 ```
 
-##### Response
-
-```json
-{
-  "municipality": {
-    "id": 1,
-    "name": "Álvaro Obregón",
-    "municipality_key": "010",
-    "zip_code": "01001",
-    "state_id": 1
-  }
-}
-```
-
-### Cities
-
-#### all
-
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/cities
-```
-
-##### Response
-
-```json
-{
-  "cities": [
-    {
-      "id": 1,
-      "name": "Ciudad de México",
-      "state_id": 1
-    },
-  ...
-  ],
-  "meta": {
-    "pagination": {
-      "per_page": 15,
-      "total_pages": 45,
-      "total_objects": 669,
-      "links": {
-        "first": "/city?page=1",
-        "last": "/city?page=45",
-        "next": "/city?page=2"
-      }
-    }
-  }
-}
-```
-
-#### by id
-
-```bash
-curl -X GET https://sepomex.icalialabs.com/api/v1/cities/1
-```
-
-##### Response
-
-```json
-{
-  "city": {
-    "id": 1,
-    "name": "Ciudad de México",
-    "state_id": 1
-  }
-}
-```
-
-## About pagination
-
-The structure of a paged response is:
+Each response includes a `meta.pagination` block:
 
 ```json
 "meta": {
-    "pagination": {
-      "per_page": 15,
-      "total_pages": 9728,
-      "total_objects": 145906,
-      "links": {
-        "first": "/zip_code?page=1",
-        "last": "/zip_code?page=9728",
-        "prev": "/zip_code?page=1",
-        "next": "/zip_code?page=3"
-      }
+  "pagination": {
+    "per_page": 15,
+    "total_pages": 9728,
+    "total_objects": 145906,
+    "links": {
+      "first": "/api/v1/zip_codes?page=1",
+      "last": "/api/v1/zip_codes?page=9728",
+      "prev": "/api/v1/zip_codes?page=1",
+      "next": "/api/v1/zip_codes?page=3"
     }
   }
+}
 ```
 
-**Where:**
+The same numbers are also returned as `Link`, `X-Total-Pages` and `X-Total-Count` response headers.
 
-- ``per_page`` is the amount of elements per page.
-- ``total_pages`` is the total number of pages.
-- ``total_objects`` is the total objects of all pages.
-- ``links`` contains links for pages.
-  - ``first``is the url for the first page.
-  - ``last`` is the url for the last page.
-  - ``prev`` is the url for the previous page.
-  - ``next`` is the url for the next page.
+## 🤖 MCP server
 
-## MCP (Model Context Protocol)
-
-Beyond the REST API, Sepomex ships a **Model Context Protocol** server so AI
-agents (Claude Desktop, Claude Code, Cursor, …) can query Mexican postal codes
-as tools. Both transports below serve the same tools and reuse the same models
-as the REST API.
-
-### Tools
+Sepomex ships a **Model Context Protocol** server so AI agents (Claude Desktop, Claude Code, Cursor, …) can query the catalog as tools. Every tool reuses the exact models and serializers behind the REST API, so both surfaces stay in sync.
 
 | Tool | Description | Arguments |
 | --- | --- | --- |
-| `lookup_zip_code` | All settlements (colonias) for one exact CP | `zip_code` (required) |
+| `lookup_zip_code` | All settlements for one exact CP | `zip_code` *(required)* |
 | `search_zip_codes` | Filter settlements | `zip_code`, `state`, `city`, `colony`, `limit` |
 | `list_states` | The 32 states | — |
-| `state_municipalities` | Municipalities of a state | `state_id` (required) |
+| `state_municipalities` | Municipalities of a state | `state_id` *(required)* |
 | `search_cities` | Cities by name | `query`, `limit` |
 
-Each tool returns a human-readable summary plus `structuredContent` (the same
-fields as the REST serializers).
+Each tool returns a human-readable summary **and** `structuredContent` (the same fields as the REST serializers).
 
-### HTTP (Streamable HTTP)
-
-The server is mounted at `/mcp` (stateless), alongside the REST API, so any
-Streamable-HTTP MCP client can point at `https://<your-host>/mcp`:
+**Streamable HTTP** — mounted at `/mcp`, alongside the REST API:
 
 ```bash
 curl -X POST http://localhost:3000/mcp \
@@ -398,103 +224,96 @@ curl -X POST http://localhost:3000/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"lookup_zip_code","arguments":{"zip_code":"64000"}}}'
 ```
 
-### stdio (local)
-
-`bin/mcp` serves the protocol over stdin/stdout against the local database. Add
-it to your MCP client config (e.g. Claude Desktop's `claude_desktop_config.json`):
+**stdio** — `bin/mcp` serves the protocol over stdin/stdout against the local database. Add it to your client config:
 
 ```json
 {
   "mcpServers": {
-    "sepomex": {
-      "command": "/absolute/path/to/sepomex/bin/mcp"
-    }
+    "sepomex": { "command": "/absolute/path/to/sepomex/bin/mcp" }
   }
 }
 ```
 
-By default it uses the development database; set `RAILS_ENV=production` to serve
-the bundled production catalog instead.
+By default `bin/mcp` uses the development database; set `RAILS_ENV=production` to serve the bundled production catalog.
 
-## Development
+## 🛠️ Development
 
-The data lives in a bundled SQLite database, so there is no external database
-service to run. You can set the project up locally with `rbenv`/`ruby` or with
-Docker.
+The dataset lives in a bundled SQLite database, so there's no external service to run. Set up locally with `rbenv`/`ruby` or with Docker.
 
-**Local setup (rbenv / ruby)**
+**Local (rbenv / ruby)**
 
 ```bash
-$ git clone git@github.com:IcaliaLabs/sepomex.git
-$ cd sepomex
-$ bundle install
-$ bin/rails db:prepare        # create the SQLite database + load the schema
-$ bin/rake data:loadev        # import the ~154k settlements from the bundled CSV
-$ bin/rails server            # http://localhost:3000
+git clone git@github.com:IcaliaLabs/sepomex.git
+cd sepomex
+bundle install
+bin/rails db:prepare        # create the SQLite database + load the schema
+bin/rake data:loadev        # import the ~154k settlements from the bundled CSV
+bin/rails server            # http://localhost:3000
 ```
 
-`rake data:loadev` loads the settlements, states, municipalities and cities from
-`lib/sepomex_db.csv` and builds the search indexes; it only runs when the
-database is empty.
-
-**Docker setup**
+**Docker**
 
 ```bash
-$ git clone git@github.com:IcaliaLabs/sepomex.git
-$ cd sepomex
-# Open a shell in the development container:
-$ docker compose run --rm development bash
-# Inside the container, prepare and seed the database:
-$ bin/rails db:prepare
-$ bin/rake data:loadev
-$ exit
-```
-
-**Running the project (Docker)**
-
-```bash
-$ docker compose up
-```
-
-The container entrypoint prepares the database automatically, and Puma listens
-on `http://localhost:3000`.
-
-**Stop the project**
-
-1. Use `Ctrl-C` to stop.
-
-2. If you want to remove the containers use:
-
-```bash
-$ docker compose down
+docker compose run --rm development bash   # shell in the dev container
+bin/rails db:prepare && bin/rake data:loadev
+exit
+docker compose up                          # http://localhost:3000
 ```
 
 **Running specs**
 
-Locally:
-
 ```bash
-$ bundle exec rspec
+bundle exec rspec                 # locally
+docker compose run --rm tests     # in the container (as CI does)
 ```
 
-Or, in the tests container (as CI does):
+### Refreshing the data
+
+Update the bundled dataset from the latest official [SEPOMEX export](https://www.correosdemexico.gob.mx/SSLServicios/ConsultaCP/CodigoPostal_Exportar.aspx) (a `CPdescarga.xml` file):
 
 ```bash
-$ docker compose run --rm tests
+rake "data:import_xml[/path/to/CPdescarga.xml]"   # regenerate lib/sepomex_db.csv
+bin/rails db:reset && rake data:loadev            # rebuild the DB from it
 ```
 
-## Changelog
+`data:import_xml` streams the XML (so the ~67 MB file never loads fully into memory) and writes the pipe-delimited CSV the loader consumes.
+
+## 🧱 Architecture
+
+```
+app/
+├── controllers/
+│   ├── api/v1/                     # REST endpoints (zip_codes, states, municipalities, cities)
+│   ├── concerns/paginatable.rb     # meta.pagination + Link / X-Total-* contract
+│   └── mcp_controller.rb           # MCP over Streamable HTTP  →  POST /mcp
+├── mcp/sepomex_mcp/                # MCP server + the 5 tools
+├── models/                         # ZipCode, State, Municipality, City, FtsZipCode
+├── serializers/                    # Active Model Serializers (:json adapter)
+└── services/                       # CSV loader + XML→CSV importer
+bin/mcp                             # MCP over stdio
+lib/sepomex_db.csv                  # bundled dataset (~154k rows)
+```
+
+**Stack:** Ruby 3.4 · Rails 8.1 (API-only) · SQLite · Puma · Active Model Serializers · [`mcp`](https://github.com/modelcontextprotocol/ruby-sdk)
+
+## 🔁 How it ships
+
+Pushing to `main` runs the GitHub Actions pipeline (`.github/workflows`): it builds the Docker `testing` image, runs the spec suite, then builds and pushes the `release` image to **Docker Hub** (`icalia/sepomex`). The production image bakes the SQLite catalog at build time; hosting runs on **Azure Web Apps**.
+
+## 🗺️ Roadmap
+
+- Automate the data refresh from the official XML export.
+- Optional bearer-token gating for the MCP endpoint.
+- Deeper agentic tooling (specialist agents / plugins).
+
+## 📓 Changelog
 
 Notable changes are recorded in [CHANGELOG.md](CHANGELOG.md).
 
-## Contributing
+## 🤝 Contributing
 
-Please submit all pull requests against a separate branch.
+Pull requests are welcome — please branch off `main` and open one against a separate branch. This project follows the [Contributor Covenant](http://contributor-covenant.org/version/1/2/0/).
 
-### Code of conduct
+## 📄 License
 
-This project adheres to the [Contributor Covenant 1.2](http://contributor-covenant.org/version/1/2/0/). By participating, you are expected to honor this code.
-
-## Copyright and license
-
-Code and documentation copyright 2013-2026 Icalia Labs. Code released under [the MIT license](LICENSE).
+Code and documentation © 2013–2026 [Icalia Labs](https://github.com/IcaliaLabs), released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

Rewrites the README into a modern, scannable landing page styled after [kurenn/trove](https://github.com/kurenn/trove):

- **Centered hero** — title, tagline, one-line value prop, shields.io badges (release, build, Ruby, Rails, MCP, license) and a nav bar.
- **Why Sepomex? / ✨ Features** narrative with emoji bullets.
- **🧭 Querying the API** — a resources table, search examples, and verbose JSON responses tucked into `<details>` so the page stays skimmable.
- **🤖 MCP server** — tools table + HTTP/stdio usage.
- **🛠️ Development** — local + Docker setup, specs, and data refresh.
- **🧱 Architecture** — directory tree + tech-stack line.
- **🔁 How it ships / 🗺️ Roadmap / 📓 Changelog / 🤝 Contributing / 📄 License** footer.

Also fixes long-standing bugs in the old README: the malformed nested code fences under "Items per page" and the resource links that pointed at `/zip_codes` instead of `/api/v1/zip_codes`.

## Notes
- Docs-only change.
- Overlaps with the README hunk in #88 (the "Refreshing the data" section) — this rewrite already **includes** that content, so on merge take this version / drop #88's README hunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)