### PR TITLE
CI: run tests, security analysis & lint on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+# Runs the test suite, security analysis and lint on every pull request and on
+# pushes to main. This is separate from `ci-and-cd.yml`, which builds and ships
+# the Docker images.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Tests (RSpec)
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # installs gems (from .ruby-version) and caches them
+
+      - name: Prepare the test database
+        run: bin/rails db:test:prepare
+
+      - name: Run specs
+        run: bundle exec rspec
+
+  security:
+    name: Security (Brakeman + bundler-audit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Brakeman (static app security analysis)
+        run: bundle exec brakeman --no-pager --exit-on-warn --exit-on-error
+
+      - name: bundler-audit (known gem vulnerabilities)
+        run: bundle exec bundle-audit check --update
+
+  lint:
+    name: Lint (RuboCop)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need history to diff changed files
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: RuboCop on changed Ruby files
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+          files=$(git diff --name-only --diff-filter=ACMR "$base"...HEAD -- '*.rb' | tr '\n' ' ')
+          if [ -z "$(echo "$files" | tr -d '[:space:]')" ]; then
+            echo "No Ruby files changed — nothing to lint."
+          else
+            echo "Linting changed files: $files"
+            bundle exec rubocop --format github $files
+          fi

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,14 @@ Metrics/BlockLength:
     - 'lib/tasks/**/*'
     - 'spec/**/*'
 
+# These are custom named scopes on ZipCode, not dynamic finders.
+Rails/DynamicFindBy:
+  AllowedMethods:
+    - find_by_zip_code
+    - find_by_state
+    - find_by_city
+    - find_by_colony
+
 RSpec/MultipleExpectations:
   Max: 5
 

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,10 @@ group :development, :test do
 end
 
 group :development do
+  # Security scanners (also run in CI):
+  gem 'brakeman', require: false
+  gem 'bundler-audit', require: false
+
   # Ruby code linters:
   gem 'reek', '~> 6.3', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,12 @@ GEM
     bigdecimal (4.1.2)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
+    brakeman (8.0.5)
+      racc
     builder (3.3.0)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     case_transform (0.2)
       activesupport
     commander (5.0.0)
@@ -436,6 +441,8 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.14)
   bootsnap (>= 1.18)
+  brakeman
+  bundler-audit
   csv (~> 3.3)
   debug
   factory_bot_rails (~> 6.4)

--- a/app/models/fts_zip_code.rb
+++ b/app/models/fts_zip_code.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+# Search-helper table populated by ZipCode.build_indexes. Holds the
+# accent-/case-normalized city, state, settlement and municipality strings the
+# ZipCode search scopes match against with LIKE.
 class FtsZipCode < ApplicationRecord
-  self.primary_key = :rowid
 end

--- a/app/models/zip_code.rb
+++ b/app/models/zip_code.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# A settlement (colonia) row from the SEPOMEX catalog — the core searchable
+# record. `ZipCode.search` powers both the REST endpoint and the MCP tool, and
+# `build_indexes` maintains the fts_zip_codes helper table used by the search
+# scopes.
 class ZipCode < ApplicationRecord
   has_one :fts_zip_code, dependent: :destroy
   validates :d_codigo, presence: true
@@ -77,22 +81,24 @@ class ZipCode < ApplicationRecord
     )
   end
 
+  FTS_COLUMNS = %w[d_ciudad d_estado d_asenta d_mnpio].freeze
+
+  # Rebuilds the full-text helper table (fts_zip_codes) from every zip code,
+  # storing the accent-/case-normalized values the search scopes match against.
+  # Uses insert_all in batches to stay within SQLite's bound-parameter limit.
   def self.build_indexes
-    values = all.map { |item| build_index(item) }
-    sql = <<~SQL.strip
-      INSERT INTO fts_zip_codes (zip_code_id, d_ciudad, d_estado, d_asenta, d_mnpio)
-      VALUES #{values.join(',')}
-    SQL
-    connection.execute sql
+    all.in_batches(of: 5_000) do |batch|
+      rows = batch.map do |item|
+        { zip_code_id: item.id }.merge(
+          FTS_COLUMNS.index_with { |column| alpharize(item[column].to_s) }
+        )
+      end
+      # fts_zip_codes is a denormalized search index with no validations.
+      FtsZipCode.insert_all(rows) # rubocop:disable Rails/SkipsModelValidations
+    end
   end
 
   def self.alpharize(text)
     text.downcase.parameterize(separator: ' ')
-  end
-
-  def self.build_index(item)
-    "(#{item.attributes.slice('id', 'd_ciudad', 'd_estado', 'd_asenta', 'd_mnpio').transform_values do |v|
-      ("'#{v.to_s.downcase.parameterize(separator: ' ')}'" unless v.is_a? Integer || v.blank?) || v
-    end.values.join(',')})"
   end
 end


### PR DESCRIPTION
## Summary

Adds a `CI` workflow (`.github/workflows/ci.yml`) that runs on **every pull request** and on pushes to `main`, complementing the existing `ci-and-cd.yml` (which builds/ships Docker images). Three parallel jobs:

| Job | What it runs |
| --- | --- |
| **Tests** | `bundle install` (Ruby from `.ruby-version`), `db:test:prepare`, `bundle exec rspec` |
| **Security** | **Brakeman** static analysis (`--exit-on-warn`) + **bundler-audit** for known gem CVEs |
| **Lint** | **RuboCop** on the PR's *changed* Ruby files (so legacy files don't block, new code stays clean) |

## Making the security scan green (no suppressions)
Brakeman flagged one real code smell — `ZipCode.build_indexes` built a raw `INSERT … VALUES` string. Rather than suppress it:
- Rewrote it to use **batched `insert_all`** (safe, parameterized) — and removed the vestigial `self.primary_key = :rowid` from `FtsZipCode` (under the current schema the table is a plain table with an `id` column).
- Added `brakeman` + `bundler-audit` to the Gemfile so CI and local dev use the same versions.
- Whitelisted the custom `find_by_*` **scopes** for `Rails/DynamicFindBy` (false positives) and documented the intentional `insert_all` validation skip.

## Verified locally
- `bundle exec rspec` → **47 examples, 0 failures**
- Brakeman → **0 warnings**; bundler-audit → **no vulnerabilities**
- RuboCop clean on changed files
- `build_indexes` rebuilds all **154,650** fts rows in ~6.6s

## Ideas for later
CodeQL (GitHub code scanning), Dependabot, coverage reporting — happy to add if you want them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)