### PR TITLE
Fix the CI & CD (Docker) build

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -73,11 +73,12 @@ jobs:
         run: docker compose run --rm tests
 
       - name: Archive system spec screenshots
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: system-spec-screenshots
           retention-days: 7
+          if-no-files-found: ignore
           path: |
             tmp/capybara/screenshots
 

--- a/bin/dev-entrypoint
+++ b/bin/dev-entrypoint
@@ -25,11 +25,14 @@ run 'bundle check > /dev/null 2>&1 || bundle install'
 command = ARGV.first
 
 if %w[rails rake rspec puma].include?(command)
-  # Create + migrate the database if it isn't ready yet (idempotent):
-  run 'bundle exec rails db:prepare'
-
-  # Prepare the test database before running the suite:
-  run 'bundle exec rails db:test:prepare' if command == 'rspec'
+  # Prepare the database (create + load schema, idempotent). db:prepare — not
+  # db:test:prepare — because the SQL schema format (FTS5) trips the latter's
+  # environment check. Specs run against the test database.
+  if command == 'rspec'
+    run 'RAILS_ENV=test bundle exec rails db:prepare'
+  else
+    run 'bundle exec rails db:prepare'
+  end
 
   # Remove a possibly pre-existing server.pid before booting the server:
   if command == 'rails' && ARGV[1].to_s.start_with?('s')


### PR DESCRIPTION
## What was broken

The **"CI & CD"** workflow (Docker image build + push) has been failing on every push to `main` — at the **"Set up job"** step, before any code ran:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3.1.0`.

GitHub now hard-fails runs referencing the deprecated v3 artifact actions. This is a **pre-existing** issue (the legacy `test-and-build.yml` used `@v3.1.0`), unrelated to the recent feature work — the app-level **CI** workflow has been green throughout.

## Fixes
- `actions/upload-artifact@v3.1.0` → **`@v4`** (+ `if-no-files-found: ignore`, since this API app has no Capybara/system specs).
- `bin/dev-entrypoint` (used by `docker compose run --rm tests`): prepare the test DB with **`RAILS_ENV=test db:prepare`** instead of `db:test:prepare`, which trips the environment check under the SQL schema format (FTS5 / `structure.sql`).

## Verified locally
- `docker compose run --rm tests` → **71 examples, 0 failures**
- Release image **builds** (`db:migrate` + `data:load` + FTS5 index) and **boots**; `/api/v1/zip_codes?state=nuevo leon` returns **5,230** results from the baked-in data.

> Note: the release-image **push** still depends on the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets being set — those are unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)