### PR TITLE
Repo hardening: LICENSE, community files, Dependabot, data refresh, secrets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
 .git/
 .gitignore
 
+# Never bake the credentials master key into the image — production reads
+# SECRET_KEY_BASE (or RAILS_MASTER_KEY) from the environment.
+config/master.key
+
 Dockerfile
 docker-compose.yml
 *.env

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report something that isn't working
+title: ''
+labels: bug
+assignees: ''
+---
+
+**What happened**
+A clear description of the bug.
+
+**To reproduce**
+The request (endpoint + params) or steps that trigger it, e.g.:
+
+```bash
+curl "http://localhost:3000/api/v1/zip_codes?zip_code=64000"
+```
+
+**Expected behavior**
+What you expected instead.
+
+**Actual response**
+The JSON / status you got.
+
+**Environment**
+- Hosted API or self-hosted? (version / commit if known)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/IcaliaLabs/sepomex/security/advisories/new
+    about: Please report security issues privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**What would you like?**
+A clear description of the feature or change.
+
+**Why**
+The problem it solves or the use case it enables.
+
+**Alternatives considered**
+Anything you've already tried or ruled out.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What does this change and why? -->
+
+## Changes
+
+<!-- Bullet the notable changes. -->
+
+## Verification
+
+<!-- How did you test it? -->
+
+- [ ] `bundle exec rspec` passes
+- [ ] `bundle exec rubocop` clean
+- [ ] `bundle exec brakeman` clean
+- [ ] The public REST API contract is unchanged (or the change is intentional and documented)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Ruby gems
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      rails:
+        patterns:
+          - "rails"
+          - "action*"
+          - "active*"
+          - "railties"
+
+  # GitHub Actions (keeps the workflows off deprecated action versions)
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -1,0 +1,67 @@
+name: Refresh dataset
+
+# Regenerates lib/sepomex_db.csv from the latest official SEPOMEX XML export and
+# opens a PR when the data changes.
+#
+# The official export (CodigoPostal_Exportar.aspx) is behind a web form, so it
+# has no stable direct-download URL. Provide the URL of a `CPdescarga.xml` via
+# the workflow_dispatch input or a `SEPOMEX_XML_URL` repository variable; the
+# scheduled run is a no-op when neither is set.
+on:
+  workflow_dispatch:
+    inputs:
+      xml_url:
+        description: URL to a SEPOMEX CPdescarga.xml export
+        required: false
+  schedule:
+    - cron: "0 6 1 * *" # 06:00 UTC on the 1st of each month
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    name: Refresh dataset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Resolve the XML source
+        id: src
+        run: |
+          url="${{ github.event.inputs.xml_url }}"
+          [ -z "$url" ] && url="${{ vars.SEPOMEX_XML_URL }}"
+          if [ -z "$url" ]; then
+            echo "No xml_url input or SEPOMEX_XML_URL variable set — nothing to do."
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Download the SEPOMEX XML
+        if: steps.src.outputs.url != ''
+        run: curl -fSL "${{ steps.src.outputs.url }}" -o "${RUNNER_TEMP}/CPdescarga.xml"
+
+      - name: Regenerate lib/sepomex_db.csv
+        if: steps.src.outputs.url != ''
+        run: bundle exec rake "data:import_xml[${RUNNER_TEMP}/CPdescarga.xml]"
+
+      - name: Open a PR if the dataset changed
+        if: steps.src.outputs.url != ''
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/refresh-dataset
+          add-paths: lib/sepomex_db.csv
+          commit-message: Refresh lib/sepomex_db.csv from the latest SEPOMEX export
+          title: Refresh postal-code dataset
+          labels: data
+          body: |
+            Automated refresh of `lib/sepomex_db.csv` from the latest official
+            SEPOMEX XML export.
+
+            After merging, the next release image bakes in the new data; to update
+            a running/local database, run `bin/rails db:reset && rake data:loadev`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,11 @@ bin/mcp                       # MCP server over stdio (RAILS_ENV=development by 
 ```
 
 CI (`.github/workflows`) builds the Dockerfile `testing` + `release` targets and
-runs `docker compose run --rm tests`, pushing images to Docker Hub. Hosting is on
-Azure Web Apps. The Ruby version is set **only** in the `Dockerfile` and
-`.ruby-version`, not in workflow YAML.
+runs `docker compose run --rm tests`, pushing the release image to Docker Hub
+(`icalia/sepomex`) to be deployed to any container host. Production reads
+`SECRET_KEY_BASE` from the environment (not baked into the image). The Ruby
+version is set **only** in the `Dockerfile` and `.ruby-version`, not in workflow
+YAML.
 
 ## Architecture
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -57,7 +57,7 @@ an individual is officially representing the community in public spaces.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**opensource@icalialabs.com**. All complaints will be reviewed and investigated
+**hola@icalialabs.com**. All complaints will be reviewed and investigated
 promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**opensource@icalialabs.com**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to Sepomex
+
+Thanks for your interest in improving Sepomex! This guide covers how to get set
+up and what we expect from a pull request.
+
+## Getting set up
+
+```bash
+git clone git@github.com:IcaliaLabs/sepomex.git
+cd sepomex
+bundle install
+bin/rails db:prepare        # create the SQLite database + load the schema
+bin/rake data:loadev        # import the ~154k settlements from the bundled CSV
+bin/rails server            # http://localhost:3000
+```
+
+See the [README](README.md) for the Docker workflow and more detail.
+
+## Making a change
+
+We use the [roundhouse](https://github.com/kurenn/roundhouse) Rails agent for
+feature work — see [CLAUDE.md](CLAUDE.md) — but any workflow is welcome. Whatever
+you use:
+
+1. Branch off `main` (`git checkout -b my-change`).
+2. Keep the **public REST API contract stable** (root keys + `meta.pagination`).
+   It's covered by request specs under `spec/requests`.
+3. Add or update tests. Run the suite and the checks locally:
+
+   ```bash
+   bundle exec rspec        # tests (aim to keep coverage up)
+   bundle exec rubocop      # lint
+   bundle exec brakeman     # security scan
+   ```
+
+4. Open a PR against `main` with a clear description. CI runs the tests,
+   security analysis and lint on every PR.
+
+## Reporting bugs / requesting features
+
+Open an issue using one of the [templates](.github/ISSUE_TEMPLATE). For security
+issues, please follow [SECURITY.md](SECURITY.md) instead of opening a public
+issue.
+
+## Code of conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By
+participating you agree to uphold it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -246,10 +246,12 @@ RUN SECRET_KEY_BASE=10167c7f7654ed02b3557b05b88ece rails secret > /dev/null
 # Set the installed app directory as the working directory:
 WORKDIR /workspaces/sepomex
 
-# Generate the sqlite production database:
-RUN rails db:create \
- && rails db:migrate \
- && rake data:load
+# Generate the sqlite production database. A throwaway SECRET_KEY_BASE lets the
+# app boot for these build-time tasks (they don't use it); the real value is
+# provided via SECRET_KEY_BASE / RAILS_MASTER_KEY in the environment at runtime.
+RUN SECRET_KEY_BASE=build_time_placeholder rails db:create \
+ && SECRET_KEY_BASE=build_time_placeholder rails db:migrate \
+ && SECRET_KEY_BASE=build_time_placeholder rake data:load
 
 # Set the entrypoint script:
 ENTRYPOINT [ "/workspaces/sepomex/bin/entrypoint" ]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2013-2026 Icalia Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ lib/sepomex_db.csv                  # bundled dataset (~154k rows)
 
 ## 🔁 How it ships
 
-Pushing to `main` runs the GitHub Actions pipeline (`.github/workflows`): it builds the Docker `testing` image, runs the spec suite, then builds and pushes the `release` image to **Docker Hub** (`icalia/sepomex`). The production image bakes the SQLite catalog at build time; hosting runs on **Azure Web Apps**.
+Pushing to `main` runs the GitHub Actions pipeline (`.github/workflows`): it builds the Docker `testing` image, runs the spec suite, then builds and pushes the `release` image to **Docker Hub** (`icalia/sepomex`). The production image bakes the SQLite catalog at build time and can be deployed to any container host; set a `SECRET_KEY_BASE` in that environment (it isn't baked into the image).
 
 ## 🗺️ Roadmap
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Please **do not** open a public issue for security problems.
 
 Report vulnerabilities privately via GitHub's
 [Security Advisories](https://github.com/IcaliaLabs/sepomex/security/advisories/new),
-or by email to **opensource@icalialabs.com**. We'll acknowledge your report as
+or by email to **hola@icalialabs.com**. We'll acknowledge your report as
 quickly as we can and keep you updated on the fix.
 
 ## Supported versions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+Report vulnerabilities privately via GitHub's
+[Security Advisories](https://github.com/IcaliaLabs/sepomex/security/advisories/new),
+or by email to **opensource@icalialabs.com**. We'll acknowledge your report as
+quickly as we can and keep you updated on the fix.
+
+## Supported versions
+
+The `main` branch (and the latest tagged release) receive security fixes.
+
+## Scope notes
+
+Sepomex is a **read-only, public** API over public postal-code data. It stores
+no user data and performs no writes at runtime, so the attack surface is small.
+Automated checks run on every pull request:
+
+- **Brakeman** — static application security analysis
+- **bundler-audit** — known-vulnerable gem dependencies
+
+## Secrets
+
+Production requires a `SECRET_KEY_BASE` (or `RAILS_MASTER_KEY`) provided via the
+environment — never commit it. `config/master.key` is intentionally **not**
+tracked in version control.

--- a/config/master.key
+++ b/config/master.key
@@ -1,1 +1,0 @@
-de35b74b9dcb003be34f4b4cb7d460a1


### PR DESCRIPTION
Rounds out the repo's OSS/ops hygiene.

## Added
- **`LICENSE`** (MIT) — the README already claimed MIT and linked to a `LICENSE` file that didn't exist.
- **Community files**: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `SECURITY.md`, issue templates (+ config), PR template.
- **`.github/dependabot.yml`** for `bundler` + `github-actions` — the latter would have caught the deprecated `upload-artifact@v3` / old buildx that recently broke CI & CD.
- **`Refresh dataset` workflow** — given a SEPOMEX XML URL (a `workflow_dispatch` input or a `SEPOMEX_XML_URL` repo variable), it regenerates `lib/sepomex_db.csv` via `data:import_xml` and opens a PR when the data changed. (The official export is behind a web form, so there's no stable direct-download URL — hence the URL input.)

## Security: stop committing `config/master.key`
It was force-added despite being in `.gitignore`. This untracks it and keeps it out of the Docker image. The credentials file holds only the default `secret_key_base` (no real secrets, and nothing reads credentials at runtime), so exposure was low — but it shouldn't be in a public repo.

> [!IMPORTANT]
> **Before this deploys to Azure**, set a **`SECRET_KEY_BASE`** app setting (value: run `bin/rails secret`). Production requires it, and it's no longer baked into the image. CI and the Docker **build** are unaffected (test env doesn't need it; the build uses a throwaway one) — only the **runtime** needs the env var. Since the API has no sessions/cookies, rotating the key has no user-facing effect.

## Verified
- `rspec` → **71 examples, 0 failures** with the master key absent.
- Release image **builds without** `master.key` and **boots + serves FTS5 search** when `SECRET_KEY_BASE` is provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)