### PR TITLE
Wire the monthly data refresh + document the hosted instance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,15 @@ spec/
 # Ignore database dumps
 db/dumps/*
 !db/dumps/.keep
+
+# Never ship local dev/test databases (33MB+) — the release stage builds
+# db/production.sqlite3 from scratch via db:create + db:migrate + data:load.
+db/*.sqlite3
+db/*.sqlite3-*
+
+# SimpleCov output.
+coverage/
+
+# Fly.io deploy config — not part of the app image.
+fly.toml
+.fly/

--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -1,17 +1,18 @@
 name: Refresh dataset
 
-# Regenerates lib/sepomex_db.csv from the latest official SEPOMEX XML export and
+# Regenerates lib/sepomex_db.csv from the latest official SEPOMEX export and
 # opens a PR when the data changes.
 #
-# The official export (CodigoPostal_Exportar.aspx) is behind a web form, so it
-# has no stable direct-download URL. Provide the URL of a `CPdescarga.xml` via
-# the workflow_dispatch input or a `SEPOMEX_XML_URL` repository variable; the
-# scheduled run is a no-op when neither is set.
+# The scheduled run is self-contained: `rake data:refresh` downloads the export
+# straight from Correos de México (the CodigoPostal_Exportar.aspx WebForms
+# postback, handled by FetchSepomexExport) and regenerates the CSV — no mirror
+# URL to provision. Pass a `xml_url` on manual dispatch to import a specific,
+# already-hosted `CPdescarga.xml` instead (e.g. to reproduce a past export).
 on:
   workflow_dispatch:
     inputs:
       xml_url:
-        description: URL to a SEPOMEX CPdescarga.xml export
+        description: Optional URL to a specific SEPOMEX CPdescarga.xml (skips the live download)
         required: false
   schedule:
     - cron: "0 6 1 * *" # 06:00 UTC on the 1st of each month
@@ -19,6 +20,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: data-refresh
+  cancel-in-progress: false
 
 jobs:
   refresh:
@@ -32,26 +37,17 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Resolve the XML source
-        id: src
+      - name: Regenerate lib/sepomex_db.csv from the latest export
+        if: github.event.inputs.xml_url == ''
+        run: bundle exec rake data:refresh
+
+      - name: Regenerate lib/sepomex_db.csv from a provided URL
+        if: github.event.inputs.xml_url != ''
         run: |
-          url="${{ github.event.inputs.xml_url }}"
-          [ -z "$url" ] && url="${{ vars.SEPOMEX_XML_URL }}"
-          if [ -z "$url" ]; then
-            echo "No xml_url input or SEPOMEX_XML_URL variable set — nothing to do."
-          fi
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-
-      - name: Download the SEPOMEX XML
-        if: steps.src.outputs.url != ''
-        run: curl -fSL "${{ steps.src.outputs.url }}" -o "${RUNNER_TEMP}/CPdescarga.xml"
-
-      - name: Regenerate lib/sepomex_db.csv
-        if: steps.src.outputs.url != ''
-        run: bundle exec rake "data:import_xml[${RUNNER_TEMP}/CPdescarga.xml]"
+          curl -fSL "${{ github.event.inputs.xml_url }}" -o "${RUNNER_TEMP}/CPdescarga.xml"
+          bundle exec rake "data:import_xml[${RUNNER_TEMP}/CPdescarga.xml]"
 
       - name: Open a PR if the dataset changed
-        if: steps.src.outputs.url != ''
         uses: peter-evans/create-pull-request@v8
         with:
           branch: chore/refresh-dataset
@@ -61,7 +57,7 @@ jobs:
           labels: data
           body: |
             Automated refresh of `lib/sepomex_db.csv` from the latest official
-            SEPOMEX XML export.
+            SEPOMEX export (`rake data:refresh`).
 
             After merging, the next release image bakes in the new data; to update
             a running/local database, run `bin/rails db:reset && rake data:loadev`.

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,12 @@ db/dumps/*
 !/tmp/pids/
 !/tmp/pids/.keep
 /coverage
+
+# ---------------------------------------------------------------------------
+# Deployment (Fly.io + Cloudflare) — local-only, never committed.
+# fly.toml holds infra topology; the rest can hold API tokens / secrets.
+# ---------------------------------------------------------------------------
+/fly.toml
+/.fly/
+/.env.deploy
+/deploy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Self-contained data refresh** — `rake data:refresh` downloads the latest
+  official SEPOMEX export directly (via the new `FetchSepomexExport` service,
+  which drives the `CodigoPostal_Exportar.aspx` form postback) and regenerates
+  `lib/sepomex_db.csv` in one step. The monthly `data-refresh` workflow now runs
+  it with no manually-provisioned mirror URL.
+- Documented the **hosted community instance** at `https://sepomex.kurenn.dev`
+  (README, docs site, OpenAPI `servers`) as a best-effort alternative to
+  self-hosting.
+
+### Changed
+- `data-refresh` workflow no longer no-ops without a `SEPOMEX_XML_URL` variable;
+  the scheduled run fetches the export itself (a `xml_url` dispatch input still
+  overrides it with a specific hosted file).
+- Migrated `spec_helper` off deprecated SimpleCov `add_filter`/`add_group`
+  (→ `skip`/`group`).
+
+### Removed
+- Dropped the stale `lib/sepomex_db.csv.old` snapshot (~14 MB) from the repo.
+
 ## [1.0.0] - 2026-07-17
 
 First tagged release — modernizes the stack and adds an MCP server. The public

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![MCP](https://img.shields.io/badge/MCP-ready-c2693d)](#-mcp-server)
 [![License](https://img.shields.io/badge/License-MIT-c2693d)](LICENSE)
 
-[Quick start](#-quick-start) · [Querying the API](#-querying-the-api) · [MCP server](#-mcp-server) · [Development](#️-development) · [Architecture](#-architecture)
+[Quick start](#-quick-start) · [Hosted instance](#-hosted-instance) · [Querying the API](#-querying-the-api) · [MCP server](#-mcp-server) · [Development](#️-development) · [Architecture](#-architecture)
 
 </div>
 
@@ -37,6 +37,26 @@ The whole catalog (~154k settlements) ships **inside the app as a SQLite databas
 - 🐳 **Dockerized** — multi-stage build, one-command dev environment, CI that ships images to Docker Hub.
 
 > **No key, no quota, no tracking.** Sepomex is a read-only public API over public data. Host your own in minutes — the dataset travels with the code.
+
+## 🌐 Hosted instance
+
+Sepomex is designed to be **self-hosted** — the whole catalog ships with the
+code, so standing up your own copy is [a few commands](#️-development). But if you
+just want to try it (or wire up a quick prototype), a **free public instance**
+runs at:
+
+```
+https://sepomex.kurenn.dev
+```
+
+```bash
+curl "https://sepomex.kurenn.dev/api/v1/zip_codes?zip_code=64000"
+```
+
+This is a **best-effort community instance** — a single small server, rate-limited
+to ~300 requests per 5 minutes per IP, with no uptime or availability guarantee.
+**For production traffic, or anything you depend on, run your own** (see
+[Development](#️-development)); it's the same image this instance runs.
 
 ## 🚀 Quick start
 
@@ -274,14 +294,20 @@ docker compose run --rm tests     # in the container (as CI does)
 
 ### Refreshing the data
 
-Update the bundled dataset from the latest official [SEPOMEX export](https://www.correosdemexico.gob.mx/SSLServicios/ConsultaCP/CodigoPostal_Exportar.aspx) (a `CPdescarga.xml` file):
+The bundled dataset tracks the official [SEPOMEX export](https://www.correosdemexico.gob.mx/SSLServicios/ConsultaCP/CodigoPostal_Exportar.aspx). One command downloads the latest export and regenerates the CSV:
+
+```bash
+rake data:refresh                       # download the export + rebuild lib/sepomex_db.csv
+bin/rails db:reset && rake data:loadev  # rebuild the local DB from it
+```
+
+`data:refresh` performs the export site's form postback for you (via `FetchSepomexExport`), so there's no file to download by hand. Already have a `CPdescarga.xml`? Import it directly instead:
 
 ```bash
 rake "data:import_xml[/path/to/CPdescarga.xml]"   # regenerate lib/sepomex_db.csv
-bin/rails db:reset && rake data:loadev            # rebuild the DB from it
 ```
 
-`data:import_xml` streams the XML (so the ~67 MB file never loads fully into memory) and writes the pipe-delimited CSV the loader consumes.
+Both stream the ~67 MB XML (it never loads fully into memory) and write the pipe-delimited CSV the loader consumes. A scheduled [`data-refresh` workflow](.github/workflows/data-refresh.yml) runs `data:refresh` monthly and opens a PR whenever the data changes.
 
 ## 🧱 Architecture
 
@@ -307,7 +333,6 @@ Pushing to `main` runs the GitHub Actions pipeline (`.github/workflows`): it bui
 
 ## 🗺️ Roadmap
 
-- Automate the data refresh from the official XML export.
 - Optional bearer-token gating for the MCP endpoint.
 - Deeper agentic tooling (specialist agents / plugins).
 

--- a/app/services/fetch_sepomex_export.rb
+++ b/app/services/fetch_sepomex_export.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+require 'zlib'
+
+#= FetchSepomexExport
+#
+# Downloads the official national zip-code catalog straight from Correos de
+# México and writes the raw `CPdescarga.xml` that ConvertXmlToCsv consumes.
+#
+# The export page (CodigoPostal_Exportar.aspx) is an ASP.NET WebForms page with
+# no stable direct-download URL — the file is produced by a form postback. So we
+# GET the page to harvest the postback tokens (`__VIEWSTATE`,
+# `__VIEWSTATEGENERATOR`, `__EVENTVALIDATION`), then POST them back together with
+# "all states" (`cboEdo=00`), the XML format (`rblTipo=xml`) and the image-button
+# coordinates (`btnDescarga.x/.y`). The response is a ZIP holding a single
+# `CPdescarga.xml`, which we inflate in-process — no `unzip` binary, no extra gem.
+#
+# This is what makes the monthly `data-refresh` workflow self-contained: no
+# manually-provisioned mirror URL, just run it.
+class FetchSepomexExport
+  include Performable
+
+  EXPORT_URL = 'https://www.correosdemexico.gob.mx/SSLServicios/ConsultaCP/CodigoPostal_Exportar.aspx'
+  DEFAULT_OUTPUT = Rails.root.join('tmp/CPdescarga.xml').to_s
+  USER_AGENT = 'sepomex-data-refresh (+https://github.com/IcaliaLabs/sepomex)'
+
+  # ASP.NET anti-forgery tokens the postback must echo back verbatim.
+  TOKENS = %w[__VIEWSTATE __VIEWSTATEGENERATOR __EVENTVALIDATION].freeze
+  ZIP_LOCAL_HEADER = "PK\x03\x04".b
+
+  OPEN_TIMEOUT = 30
+  READ_TIMEOUT = 180 # the export is ~3 MB gzipped but the server is slow.
+
+  def initialize(dest: DEFAULT_OUTPUT, url: EXPORT_URL)
+    @dest = dest.to_s
+    @uri = URI(url)
+    @listeners = {}
+  end
+
+  # Downloads the export, writes CPdescarga.xml to `dest`, and returns the path.
+  def perform!
+    xml = extract_single_member(download_zip(form_fields(fetch_tokens)))
+    File.binwrite(@dest, xml)
+    notify_progress(xml.bytesize)
+    @dest
+  end
+
+  def on_progress(&block)
+    @listeners[:progress] = block
+  end
+
+  # -- Testable seams (no network) ------------------------------------------
+
+  # Parses the three ASP.NET postback tokens out of the export page HTML.
+  def parse_tokens(html)
+    TOKENS.to_h do |name|
+      match = html.match(/name="#{Regexp.escape(name)}"[^>]*\svalue="([^"]*)"/)
+      raise "SEPOMEX export page is missing #{name}; the form may have changed." unless match
+
+      [name, match[1]]
+    end
+  end
+
+  # Inflates the single CPdescarga.xml member out of the downloaded ZIP archive.
+  def extract_single_member(bytes)
+    bytes = bytes.b
+    unless bytes.start_with?(ZIP_LOCAL_HEADER)
+      raise "SEPOMEX did not return a ZIP (got #{bytes[0, 48].inspect}); the export may be down."
+    end
+
+    # Local file header fields: flags, method, compressed size, name/extra lengths.
+    flags, method, comp_size, name_len, extra_len = bytes[6, 24].unpack('vv@12V@20vv')
+
+    # Bit 3 means the sizes live in a trailing data descriptor (we rely on the
+    # local header); anything but stored/deflate we don't attempt to unpack.
+    if flags.anybits?(0x08) || ![0, 8].include?(method)
+      raise 'Unexpected ZIP layout from SEPOMEX; extract CPdescarga.xml by hand and use `rake data:import_xml`.'
+    end
+
+    compressed = bytes[30 + name_len + extra_len, comp_size]
+    method.zero? ? compressed : Zlib::Inflate.new(-Zlib::MAX_WBITS).inflate(compressed)
+  end
+
+  private
+
+  def fetch_tokens
+    response = http.get(@uri.request_uri, 'User-Agent' => USER_AGENT)
+    raise "SEPOMEX export page returned HTTP #{response.code}." unless response.is_a?(Net::HTTPSuccess)
+
+    parse_tokens(response.body.force_encoding('ISO-8859-1'))
+  end
+
+  def form_fields(tokens)
+    tokens.merge(
+      '__EVENTTARGET' => '', '__EVENTARGUMENT' => '', '__LASTFOCUS' => '',
+      'cboEdo' => '00', 'rblTipo' => 'xml', 'btnDescarga.x' => '12', 'btnDescarga.y' => '12'
+    )
+  end
+
+  def download_zip(fields)
+    response = http.post(
+      @uri.request_uri, URI.encode_www_form(fields),
+      'User-Agent' => USER_AGENT,
+      'Content-Type' => 'application/x-www-form-urlencoded',
+      'Referer' => @uri.to_s
+    )
+    raise "SEPOMEX export download returned HTTP #{response.code}." unless response.is_a?(Net::HTTPSuccess)
+
+    response.body
+  end
+
+  def http
+    @http ||= Net::HTTP.new(@uri.host, @uri.port).tap do |client|
+      client.use_ssl = @uri.scheme == 'https'
+      client.open_timeout = OPEN_TIMEOUT
+      client.read_timeout = READ_TIMEOUT
+    end
+  end
+
+  def notify_progress(bytes)
+    @listeners[:progress]&.call(bytes)
+  end
+end

--- a/docs/index.html
+++ b/docs/index.html
@@ -173,12 +173,13 @@
             <div class="eyebrow">Reference</div>
             <h1>Sepomex API</h1>
             <p>Open REST API for Mexico's official postal-code (código postal) catalog — <strong>~154,650 settlements</strong> across 32 states, ~2,475 municipalities and ~660 cities, from a bundled SQLite dataset. Read-only, public, no API key.</p>
-            <p>All endpoints live under the <code class="inline">/api/v1</code> path. Prefix it with your deployment host (examples below use <code class="inline">http://localhost:3000</code> from a local run).</p>
+            <p>All endpoints live under the <code class="inline">/api/v1</code> path. Prefix it with your deployment host — the examples below use <code class="inline">http://localhost:3000</code> from a local run, but a hosted instance also runs at <code class="inline">https://sepomex.kurenn.dev</code>.</p>
             <div class="chips"><span class="chip">/api/v1</span></div>
             <div class="feature-pills">
               <span>No API key</span><span>Public</span><span>CORS-enabled</span><span>Read-only</span>
             </div>
             <p><strong>Stack:</strong> Ruby 3.4 · Rails 8.1 (API-only) · SQLite · Puma.</p>
+            <div class="callout"><p><strong>Hosted instance:</strong> try it now at <a href="https://sepomex.kurenn.dev/api/v1/zip_codes?zip_code=64000" target="_blank" rel="noopener"><code class="inline">sepomex.kurenn.dev</code></a> — a free, best-effort community instance (rate-limited, no SLA). Self-host for production; the dataset ships with the code.</p></div>
             <div class="callout"><p>AI agent? Skip the REST calls — query the same data as tools through the <a href="#mcp">MCP server</a>.</p></div>
           </div>
           <div class="code-col">

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -23,17 +23,35 @@ namespace :data do
     end
   end
 
-  desc 'Convert the official SEPOMEX XML export into lib/sepomex_db.csv'
+  def import_xml_file(xml_path)
+    converter = ConvertXmlToCsv.new(xml_path: xml_path)
+    converter.on_progress { |rows| print_flush "Converted #{rows} rows..." }
+    total = converter.perform!
+    puts "\nWrote #{total} rows to lib/sepomex_db.csv"
+    puts 'Run `rake data:load` (or data:loadev) to sync the database.'
+  end
+
+  desc 'Convert an already-downloaded SEPOMEX XML export into lib/sepomex_db.csv'
   task :import_xml, %i[xml_path] => :environment do |_task, args|
     xml_path = args[:xml_path] || ENV.fetch('XML_PATH', nil)
     if xml_path.blank?
       abort 'Usage: rake "data:import_xml[/path/to/CPdescarga.xml]" (or XML_PATH=... rake data:import_xml)'
     end
 
-    converter = ConvertXmlToCsv.new(xml_path: xml_path)
-    converter.on_progress { |rows| print_flush "Converted #{rows} rows..." }
-    total = converter.perform!
-    puts "\nWrote #{total} rows to lib/sepomex_db.csv"
-    puts 'Run `rake data:load` (or data:loadev) to sync the database.'
+    import_xml_file(xml_path)
+  end
+
+  desc 'Download the latest official SEPOMEX export and regenerate lib/sepomex_db.csv'
+  task refresh: :environment do
+    require 'tmpdir'
+
+    Dir.mktmpdir('sepomex-refresh') do |dir|
+      xml_path = File.join(dir, 'CPdescarga.xml')
+      fetch = FetchSepomexExport.new(dest: xml_path)
+      fetch.on_progress { |bytes| print_flush "Downloaded #{bytes} bytes of XML..." }
+      fetch.perform!
+
+      import_xml_file(xml_path)
+    end
   end
 end

--- a/spec/services/fetch_sepomex_export_spec.rb
+++ b/spec/services/fetch_sepomex_export_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'zlib'
+
+RSpec.describe FetchSepomexExport do
+  subject(:service) { described_class.new }
+
+  # Builds a minimal single-member ZIP the way the real export arrives:
+  # one deflate-compressed local file entry (flags = 0, method = 8), which is the
+  # exact layout FetchSepomexExport#extract_single_member relies on.
+  def zip_with(payload, name: 'CPdescarga.xml')
+    body = Zlib::Deflate.deflate(payload)[2...-4] # strip zlib header + adler32 -> raw deflate
+    [
+      "PK\x03\x04",                 # local file header signature
+      [20].pack('v'),               # version needed
+      [0].pack('v'),                # flags (sizes in header, no data descriptor)
+      [8].pack('v'),                # method: deflate
+      [0, 0].pack('v2'),            # mod time / date
+      [0].pack('V'),                # crc32 (unchecked here)
+      [body.bytesize].pack('V'),    # compressed size
+      [payload.bytesize].pack('V'), # uncompressed size
+      [name.bytesize].pack('v'),    # filename length
+      [0].pack('v'),                # extra length
+      name.b,
+      body
+    ].join.b
+  end
+
+  describe '#parse_tokens' do
+    let(:html) do
+      <<~HTML
+        <form method="post" action="CodigoPostal_Exportar.aspx">
+          <input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="dExampleViewState+/=" />
+          <input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="C0FFEE01" />
+          <input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="ev+Validation/=" />
+        </form>
+      HTML
+    end
+
+    it 'extracts the three ASP.NET postback tokens verbatim' do
+      expect(service.parse_tokens(html)).to eq(
+        '__VIEWSTATE' => 'dExampleViewState+/=',
+        '__VIEWSTATEGENERATOR' => 'C0FFEE01',
+        '__EVENTVALIDATION' => 'ev+Validation/='
+      )
+    end
+
+    it 'raises a helpful error when a token is missing (the form changed)' do
+      expect { service.parse_tokens('<form></form>') }
+        .to raise_error(/__VIEWSTATE.*form may have changed/)
+    end
+  end
+
+  describe '#extract_single_member' do
+    it 'inflates the single XML member from a deflate ZIP' do
+      xml = '<NewDataSet><table><d_codigo>64000</d_codigo></table></NewDataSet>'
+      expect(service.extract_single_member(zip_with(xml))).to eq(xml)
+    end
+
+    it 'raises when the response is not a ZIP (export down / HTML error page)' do
+      expect { service.extract_single_member('<html>error</html>') }
+        .to raise_error(/did not return a ZIP/)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,12 +11,12 @@ end
 
 SimpleCov.start 'rails' do
   enable_coverage :branch
-  add_filter %w[/spec/ /config/ /db/ /bin/ /vendor/]
+  skip %w[/spec/ /config/ /db/ /bin/ /vendor/]
   # Unused Rails framework stubs in this API-only app.
-  add_filter %w[/app/channels/ /app/jobs/ /app/mailers/]
-  add_group 'MCP', 'app/mcp'
-  add_group 'Services', 'app/services'
-  add_group 'Serializers', 'app/serializers'
+  skip %w[/app/channels/ /app/jobs/ /app/mailers/]
+  group 'MCP', 'app/mcp'
+  group 'Services', 'app/services'
+  group 'Serializers', 'app/serializers'
   formatter SimpleCov::Formatter::MultiFormatter.new(
     [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::LcovFormatter]
   )

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -11,8 +11,10 @@ info:
     name: MIT
     url: https://github.com/IcaliaLabs/sepomex/blob/main/LICENSE
 servers:
+- url: https://sepomex.kurenn.dev
+  description: Hosted (best-effort community instance, rate-limited, no SLA)
 - url: http://localhost:3000
-  description: Local
+  description: Local (self-hosted)
 paths:
   "/api/v1/cities":
     get:


### PR DESCRIPTION
Three related bits of upkeep. Full suite green (75 examples), no rubocop offenses.

## 1. Self-contained monthly data refresh

The `data-refresh` workflow was gated on a `SEPOMEX_XML_URL` repo variable that was never set, so the monthly cron had produced **zero runs** (closes #57). The official export has no stable direct-download URL — it comes from an ASP.NET WebForms postback on `CodigoPostal_Exportar.aspx`.

New `FetchSepomexExport` service drives that postback:
- GET the export page → scrape `__VIEWSTATE` / `__VIEWSTATEGENERATOR` / `__EVENTVALIDATION`
- POST them back with `cboEdo=00` (all states) + `rblTipo=xml` + the image-button coords
- inflate the single `CPdescarga.xml` from the returned ZIP in-process (stdlib `Zlib` — no `unzip` binary, no new gem)

`rake data:refresh` chains the download + CSV regeneration; the workflow now runs it with **no mirror URL to provision** (a `xml_url` dispatch input still overrides it with a specific hosted file). Validated end-to-end against the live site: **158,864 records** fetched and converted (the bundled snapshot is ~154k — the data has grown). Added a spec covering the two fragile pure methods (token parsing, ZIP extraction) with no network dependency.

## 2. Hosted instance, documented

Sepomex is self-host-first (the dataset ships with the code), but nothing pointed at the running public instance — so users hitting the old dead host had nowhere to go (relevant to #75/#84/#85). Surfaced `https://sepomex.kurenn.dev` across the README, docs site and OpenAPI `servers` as a **free, best-effort community instance** — explicitly rate-limited, no SLA, with "self-host for production" called out so it stays a convenience, not a dependency.

## 3. Housekeeping

- Removed `lib/sepomex_db.csv.old` (~14 MB stale snapshot) — tracked in git and shipped in every clone / Docker build context.
- Migrated `spec_helper` off deprecated SimpleCov `add_filter`/`add_group` (→ `skip`/`group`), silencing five warnings per run.
- Ignore local Fly.io deploy config + coverage output (`.gitignore` / `.dockerignore`).

## Note on CI

`data:refresh` reaches out to the government export site during the scheduled run. Worth a one-off manual `gh workflow run data-refresh.yml` after merge to confirm it runs green on the Actions runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)